### PR TITLE
Fix print styling on final page

### DIFF
--- a/src/styles/Accordion.scss
+++ b/src/styles/Accordion.scss
@@ -1,5 +1,43 @@
 @import 'vars';
 
+// This is a TERRIBLE HACK. The embedded Google Map
+// in step 1 of the housing court page, which has
+// a map of the housing court location, won't load
+// unless the browser thinks it needs to be visible.
+// This is fine when the map is collapsed behind
+// an accordion on the screen.
+//
+// However, when the user decides to print the page,
+// the print stylesheet kicks in, which displays the
+// content of all the accordions, including the map.
+// But there's a problem, because the print version
+// is rendered as soon as this stylesheet is applied,
+// without waiting for any content inside the
+// accordion to load: the result is that the map
+// doesn't appear at all, or appears in a partially
+// loaded state.
+//
+// So instead of setting `display: none` on the
+// map accordion's collapsed content by default,
+// we'll have it display, but in an off-screen
+// area that users can't see (screen-readers
+// shouldn't be able to see it either because
+// `aria-hidden="true"` is set). This will ensure
+// the map is already loaded if/when the user decides
+// to print.
+@media screen {
+  section.HousingCourtPage
+  #accordion__body-0.accordion__body--hidden {
+    display: block;
+    position: absolute;
+    left: -10000px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+  }
+}
+
 .Accordion {
   .accordion__item {
     border-bottom: 1px solid $border-color;

--- a/src/styles/ProvidersCarousel.scss
+++ b/src/styles/ProvidersCarousel.scss
@@ -14,6 +14,11 @@
       margin-right: 0;
     }
 
+    @media print {
+      .carousel__slider-tray {
+        transform: translateX(0px) !important;
+      }
+    }
   }
 
   .carousel__slide {


### PR DESCRIPTION
This fixes some print styling issues on the final page.

## Bug 1: List of attorneys

One is that the list of attorneys is sometimes cut off:

> ![image](https://user-images.githubusercontent.com/124687/55240505-65f43100-520f-11e9-8eec-d21e6a149623.png)

This appears to happen if the carousel is in a transitional state when the page is printed. I fixed it by forcing the transition styling to not affect the print version. Easy peasy!

## Bug 2: Map

The other bug was a bit harder to fix.  Basically, if the user prints the final page without first expanding the first accordion, they often get a printed map that is empty or only partly visible, like this:

> ![image](https://user-images.githubusercontent.com/124687/55240767-05b1bf00-5210-11e9-912b-59670fb9d3c6.png)

The reasons behind this and the resulting fix is nontrivial to explain or understand from just the CSS, so I've added a big comment that explains what's going on there.  The one drawback of the fix, though, is that the fade-in effect of the accordion content (just on this first map accordion) is gone.

Note though that another solution to this particular problem is simply to display the first accordion as uncollapsed by default.
