### PR TITLE
Remove all references to the Tenant Assistance Directory

### DIFF
--- a/src/components/CommunityGroups.js
+++ b/src/components/CommunityGroups.js
@@ -94,26 +94,10 @@ class CommunityGroups extends React.Component {
                 </div>
               </div>
             )}
-            <div className="tile" key={this.state.groups.length}>
-              <div className="tile-content">
-                <p className="tile-title h5"><Trans id="groupsLookMore" /></p>
-              </div>
-              <div className="tile-action">
-                <a href="http://findhelp.justfix.nyc/" target="_blank"
-                  className="btn btn-default">
-                   <i className="icon icon-share mr-2"></i>
-                   <Trans id="website" />
-                </a>
-              </div>
-            </div>
           </div>
         ) : this.state.contentfulResponse ? (
           <div className="empty">
             <p className="empty-title h5"><Trans id="groupsEmpty" /></p>
-            <p className="empty-subtitle"><Trans id="groupsEmptySubtitle" /></p>
-            <div className="empty-action">
-              <a className="btn btn-steps" href="http://findhelp.justfix.nyc/" target="_blank"><Trans id="website" /></a>
-            </div>
           </div>
         ) : (
           <div className="empty">

--- a/src/containers/AdminHearingPage.js
+++ b/src/containers/AdminHearingPage.js
@@ -25,13 +25,6 @@ class AdminHearingPage extends React.Component {
         html: addCallButtons(step.childContentfulHousingCourtActionStepContentTextNode.childMarkdownRemark.html)
     }));
 
-    if(contentfulData.additionalResources) {
-      this.data.additionalResources = contentfulData.additionalResources.map((step, i) => ({
-          title: step.title,
-          html: addCallButtons(step.childContentfulHousingCourtActionStepContentTextNode.childMarkdownRemark.html)
-      }));
-    }
-
     this.data.providers = contentfulData.providers;
 
   }


### PR DESCRIPTION
This PR remove all references to the Tenant Assistance Directory on our result pages.
