### PR TITLE
Add `typecheck` command to CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,5 +18,5 @@ jobs: # a collection of steps
             - ./node_modules
       - run: # run tests
           name: test
-          command: yarn test
+          command: yarn typecheck && yarn test
       # See https://circleci.com/docs/2.0/deployment-integrations/ for deploy examples 

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "prettier:fix": "prettier \"**/*.{ts,tsx,js,scss}\" --write",
     "prod": "npm run build; npm run build:lambda",
     "start": "gatsby serve",
+    "typecheck": "tsc --noEmit",
     "test": "yarn prettier:check && jest",
     "test:watch": "jest --watch",
     "start:lambda": "netlify-lambda serve functions",

--- a/src/pages/admin-hearings.en-US.js
+++ b/src/pages/admin-hearings.en-US.js
@@ -1,4 +1,5 @@
-export default from "../containers/AdminHearingPage";
+import Page from "../containers/AdminHearingPage";
+export default Page;
 
 export const pageQuery = graphql`
   query AdminHearingPageEnUsQuery {

--- a/src/pages/admin-hearings.es.js
+++ b/src/pages/admin-hearings.es.js
@@ -1,4 +1,5 @@
-export default from "../containers/AdminHearingPage";
+import Page from "../containers/AdminHearingPage";
+export default Page;
 
 export const pageQuery = graphql`
   query AdminHearingPageEsQuery {

--- a/src/pages/admin-hearings.fr.js
+++ b/src/pages/admin-hearings.fr.js
@@ -1,4 +1,5 @@
-export default from "../containers/AdminHearingPage";
+import Page from "../containers/AdminHearingPage";
+export default Page;
 
 export const pageQuery = graphql`
   query AdminHearingPageFrQuery {

--- a/src/pages/admin-hearings.ht.js
+++ b/src/pages/admin-hearings.ht.js
@@ -1,4 +1,5 @@
-export default from "../containers/AdminHearingPage";
+import Page from "../containers/AdminHearingPage";
+export default Page;
 
 export const pageQuery = graphql`
   query AdminHearingPageHtQuery {

--- a/src/pages/index.en-US.js
+++ b/src/pages/index.en-US.js
@@ -1,4 +1,5 @@
-export default from "../containers/LandingPage";
+import Page from "../containers/LandingPage";
+export default Page;
 
 export const pageQuery = graphql`
   query LandingPageEnUsQuery {

--- a/src/pages/index.es.js
+++ b/src/pages/index.es.js
@@ -1,4 +1,5 @@
-export default from "../containers/LandingPage";
+import Page from "../containers/LandingPage";
+export default Page;
 
 export const pageQuery = graphql`
   query LandingPageEsQuery {

--- a/src/pages/index.fr.js
+++ b/src/pages/index.fr.js
@@ -1,4 +1,5 @@
-export default from "../containers/LandingPage";
+import Page from "../containers/LandingPage";
+export default Page;
 
 export const pageQuery = graphql`
   query LandingPageFrQuery {

--- a/src/pages/index.ht.js
+++ b/src/pages/index.ht.js
@@ -1,4 +1,5 @@
-export default from "../containers/LandingPage";
+import Page from "../containers/LandingPage";
+export default Page;
 
 export const pageQuery = graphql`
   query LandingPageHtQuery {

--- a/src/pages/questions.en-US.js
+++ b/src/pages/questions.en-US.js
@@ -1,4 +1,5 @@
-export default from "../containers/ScreenerPage";
+import Page from "../containers/ScreenerPage";
+export default Page;
 
 export const pageQuery = graphql`
   query ScreenerPageEnUsQuery {

--- a/src/pages/questions.es.js
+++ b/src/pages/questions.es.js
@@ -1,4 +1,5 @@
-export default from "../containers/ScreenerPage";
+import Page from "../containers/ScreenerPage";
+export default Page;
 
 export const pageQuery = graphql`
   query ScreenerPageEsQuery {

--- a/src/pages/questions.fr.js
+++ b/src/pages/questions.fr.js
@@ -1,4 +1,5 @@
-export default from "../containers/ScreenerPage";
+import Page from "../containers/ScreenerPage";
+export default Page;
 
 export const pageQuery = graphql`
   query ScreenerPageFrQuery {

--- a/src/pages/questions.ht.js
+++ b/src/pages/questions.ht.js
@@ -1,4 +1,5 @@
-export default from "../containers/ScreenerPage";
+import Page from "../containers/ScreenerPage";
+export default Page;
 
 export const pageQuery = graphql`
   query ScreenerPageHtQuery {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "lib": ["es6", "es7", "dom"],
     "sourceMap": true,
+    "skipLibCheck": true,
     "allowJs": true,
     "jsx": "react",
     "moduleResolution": "node",
@@ -20,5 +21,5 @@
     "downlevelIteration": true,
     "resolveJsonModule": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
 }


### PR DESCRIPTION
This PR fixes #106 by adding a `yarn typecheck` command within our package.json an calling that command when testing within our CircleCI config. It also refactors some weird `export default` statements that were causing ts errors.