### PR TITLE
Expose web textbot at `/en-US/textbot`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@types/node": "^14.11.2",
     "@types/react": "^16.9.49",
     "@types/react-dom": "^16.9.8",
+    "@types/react-router-dom": "^4.1.1",
     "@types/twilio": "^2.11.0",
     "babel-polyfill": "^6.26.0",
     "caniuse-db": "^1.0.30000652",

--- a/src/pages/textbot.en-US.tsx
+++ b/src/pages/textbot.en-US.tsx
@@ -1,0 +1,108 @@
+import React, { useEffect, useRef, useState } from "react";
+import { RouteComponentProps } from "react-router-dom";
+import "../styles/TextbotPage.scss";
+import { ConversationResponse } from "../textbot/conversation";
+
+type CallTextbotOptions = { state?: string; input?: string };
+
+const callTextbot = async ({ state, input }: CallTextbotOptions = {}) => {
+  const params = new URLSearchParams();
+  if (state) {
+    params.set("state", state);
+  }
+  params.set("input", input || "");
+  const response = await fetch(
+    `/.netlify/functions/textbot?${params.toString()}`
+  );
+  if (!response.ok) {
+    throw new Error(`Serverless handler returned HTTP ${response.status}`);
+  }
+  const result: ConversationResponse = await response.json();
+  return result;
+};
+
+// https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state
+function usePrevious<T>(value: T): T | undefined {
+  const ref = useRef<T>();
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+}
+
+function scrollElementIntoView(el: HTMLElement) {
+  setTimeout(() => {
+    el.scrollIntoView({ block: "end", inline: "nearest", behavior: "smooth" });
+    el.focus();
+  }, 10);
+}
+
+const TextbotPage: React.FC<RouteComponentProps<any>> = () => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [currInput, setCurrInput] = useState("");
+  const [lastResponse, setLastResponse] = useState<ConversationResponse | null>(
+    null
+  );
+  const prevLastResponse = usePrevious(lastResponse);
+  const [messages, setMessages] = useState<string[]>([]);
+  const isActive = lastResponse && lastResponse.conversationStatus !== "end";
+  const cycleTextbot = (options?: CallTextbotOptions) => {
+    setIsThinking(true);
+    callTextbot(options)
+      .then((res) => {
+        setCurrInput("");
+        setLastResponse(res);
+      })
+      .catch((e) => {
+        setMessages((messages) => [...messages, `ERROR: ${e}`]);
+      })
+      .finally(() => setIsThinking(false));
+  };
+  const [isThinking, setIsThinking] = useState(false);
+
+  useEffect(cycleTextbot, []);
+  useEffect(() => {
+    if (lastResponse && lastResponse !== prevLastResponse) {
+      if (lastResponse.text) {
+        setMessages((messages) => [...messages, lastResponse.text]);
+      }
+      if (lastResponse.conversationStatus === "loop") {
+        cycleTextbot({ state: lastResponse.state });
+      }
+      inputRef.current && scrollElementIntoView(inputRef.current);
+    }
+  }, [lastResponse, prevLastResponse]);
+
+  return (
+    <section className="Page TextbotPage">
+      {messages.map((message, i) => {
+        return (
+          <div key={i} style={{ whiteSpace: "pre-wrap" }}>
+            {message}
+          </div>
+        );
+      })}
+      {isActive && (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            const input = currInput;
+            const state = lastResponse ? lastResponse.state : undefined;
+            cycleTextbot({ input, state });
+          }}
+        >
+          <input
+            ref={inputRef}
+            type="text"
+            value={currInput}
+            onChange={(e) => setCurrInput(e.target.value)}
+            disabled={isThinking}
+          />
+          <button disabled={isThinking}>Send</button>
+        </form>
+      )}
+    </section>
+  );
+};
+
+export default TextbotPage;

--- a/src/styles/TextbotPage.scss
+++ b/src/styles/TextbotPage.scss
@@ -1,0 +1,3 @@
+.TextbotPage {
+  padding: 2em;
+}

--- a/src/textbot/efnyc/conversation-handlers.tsx
+++ b/src/textbot/efnyc/conversation-handlers.tsx
@@ -15,7 +15,7 @@ const INVALID_YES_OR_NO = `Sorry, I didn't understand that. Please respond with 
  * should be taken in changing its schema, since in-progress
  * conversations may end up using old versions of its schema.
  */
-type EfnycState = Partial<RtcInfo> & BaseConversationState;
+export type EfnycState = Partial<RtcInfo> & BaseConversationState;
 
 /**
  * The methods that start with `handler_` are conversation handlers.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2179,6 +2179,15 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-router-dom@^4.1.1":
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-4.3.5.tgz#72f229967690c890d00f96e6b85e9ee5780db31f"
+  integrity sha512-eFajSUASYbPHg2BDM1G8Btx+YqGgvROPIg6sBhl3O4kbDdYXdFdfrgQFf/pcBuQVObjfT9AL/dd15jilR5DIEA==
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
 "@types/react-router-dom@^4.2.2":
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-4.2.4.tgz#02c43274129ffe0ac42b348f7c8c4a9a4e127c8a"
@@ -16875,7 +16884,7 @@ twilio@^3.49.3:
     scmp "^2.1.0"
     url-parse "^1.4.7"
     xmlbuilder "^13.0.2"
-    
+
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"


### PR DESCRIPTION
This exposes the textbot on the web at `/en-US/textbot`.  It's intended primarily for development purposes, to make it easier for folks who aren't familiar with the terminal to  run the textbot.