### PR TITLE
Added new elements to landing page

### DIFF
--- a/.env.development.sample
+++ b/.env.development.sample
@@ -37,3 +37,10 @@ TWILIO_PHONE_NUMBER=
 ## If left undefined, this var will default to "www.evictionfreenyc.org." 
 
 GATSBY_EFNYC_HOST=
+
+## GATSBY_ENABLE_COMMUNITY_GROUPS_LOOKUP (Optional)
+## 
+## This feature flag, if defined, will trigger our CommunityGroups component to render
+## on our landing page. Otherwise, it will not be shown. 
+
+GATSBY_ENABLE_COMMUNITY_GROUPS_LOOKUP=

--- a/src/components/CommunityGroups.js
+++ b/src/components/CommunityGroups.js
@@ -50,52 +50,61 @@ class CommunityGroups extends React.Component {
       <div className="CommunityGroups">
         {this.state.groups.length ? (
           <div>
-            {this.state.groups.map((group, idx) => (
-              <div className="tile" key={idx}>
-                <div className="tile-icon">
-                  {group.logo && <img src={group.logo.fields.file.url} />}
-                </div>
-                <div className="tile-content">
-                  <p className="tile-title">{group.title}</p>
-                  {group.address && (
-                    <p className="tile-subtitle text-gray">
-                      <i className="icon icon-location mr-2"></i>
-                      <a
-                        href={`https://maps.google.com/maps/place/${group.address}`}
-                        target="_blank"
-                      >
-                        {group.address}
-                      </a>
-                    </p>
-                  )}
-                  {group.intakeInstructions && (
-                    <p className="title-subtitle text-gray">
-                      <i className="icon icon-time mr-2"></i>
-                      {group.intakeInstructions}
-                    </p>
-                  )}
-                  <p className="tile-subtitle text-gray">{group.description}</p>
-                  <p>
-                    <a
-                      href={`tel:${group.phoneNumber}`}
-                      className="btn btn-success"
-                    >
-                      {createFormattedTel(group.phoneNumber)}
-                    </a>
-                    {group.website && (
-                      <a
-                        href={group.website}
-                        target="_blank"
-                        className="btn btn-default btn--website"
-                      >
-                        <i className="icon icon-share mr-2"></i>
-                        <Trans id="website" />
-                      </a>
+            <div className="empty">
+              <p className="empty-title h3">
+                <Trans id="groupsSearch" />
+              </p>
+            </div>
+            <div>
+              {this.state.groups.map((group, idx) => (
+                <div className="tile" key={idx}>
+                  <div className="tile-icon">
+                    {group.logo && <img src={group.logo.fields.file.url} />}
+                  </div>
+                  <div className="tile-content">
+                    <p className="tile-title">{group.title}</p>
+                    {group.address && (
+                      <p className="tile-subtitle text-gray">
+                        <i className="icon icon-location mr-2"></i>
+                        <a
+                          href={`https://maps.google.com/maps/place/${group.address}`}
+                          target="_blank"
+                        >
+                          {group.address}
+                        </a>
+                      </p>
                     )}
-                  </p>
+                    {group.intakeInstructions && (
+                      <p className="title-subtitle text-gray">
+                        <i className="icon icon-time mr-2"></i>
+                        {group.intakeInstructions}
+                      </p>
+                    )}
+                    <p className="tile-subtitle text-gray">
+                      {group.description}
+                    </p>
+                    <p>
+                      <a
+                        href={`tel:${group.phoneNumber}`}
+                        className="btn btn-success"
+                      >
+                        {createFormattedTel(group.phoneNumber)}
+                      </a>
+                      {group.website && (
+                        <a
+                          href={group.website}
+                          target="_blank"
+                          className="btn btn-default btn--website"
+                        >
+                          <i className="icon icon-share mr-2"></i>
+                          <Trans id="website" />
+                        </a>
+                      )}
+                    </p>
+                  </div>
                 </div>
-              </div>
-            ))}
+              ))}
+            </div>
           </div>
         ) : this.state.contentfulResponse ? (
           <div className="empty">

--- a/src/components/CommunityGroups.js
+++ b/src/components/CommunityGroups.js
@@ -48,6 +48,9 @@ class CommunityGroups extends React.Component {
   render() {
     return (
       <div className="CommunityGroups">
+        <p className="empty-title h3">
+          <Trans id="groupsSearch" />
+        </p>
         {this.state.groups.length ? (
           <div>
             {this.state.groups.map((group, idx) => (

--- a/src/components/CommunityGroups.js
+++ b/src/components/CommunityGroups.js
@@ -48,9 +48,6 @@ class CommunityGroups extends React.Component {
   render() {
     return (
       <div className="CommunityGroups">
-        <p className="empty-title h3">
-          <Trans id="groupsSearch" />
-        </p>
         {this.state.groups.length ? (
           <div>
             {this.state.groups.map((group, idx) => (

--- a/src/components/CommunityGroups.js
+++ b/src/components/CommunityGroups.js
@@ -99,13 +99,13 @@ class CommunityGroups extends React.Component {
           </div>
         ) : this.state.contentfulResponse ? (
           <div className="empty">
-            <p className="empty-title h5">
+            <p className="empty-title h3">
               <Trans id="groupsEmpty" />
             </p>
           </div>
         ) : (
           <div className="empty">
-            <p className="empty-title h5">
+            <p className="empty-title h3">
               <Trans id="groupsSearch" />
             </p>
             <div className="empty-action">

--- a/src/containers/LandingPage.js
+++ b/src/containers/LandingPage.js
@@ -70,7 +70,7 @@ class LandingPage extends React.Component {
             <a
               href="https://www.righttocounselnyc.org/organizing_covid19"
               target="_blank"
-              className="btn btn-block btn-primary btn-large"
+              className="btn btn-primary btn-large"
               rel="noopener noreferrer"
             >
               {this.content.heroButtonText}

--- a/src/containers/LandingPage.js
+++ b/src/containers/LandingPage.js
@@ -18,10 +18,10 @@ const HcaPhone = () => (
   <a
     href="tel:12129624795"
     target="_blank"
-    className="text-bold"
+    className="btn btn-block btn-primary btn-large"
     rel="noopener noreferrer"
   >
-    212-962-4795
+    Call the Housing Court Answers hotline at 212-962-4795
   </a>
 );
 const RtcEmail = () => (
@@ -64,17 +64,21 @@ class LandingPage extends React.Component {
   render() {
     const isSpanish = this.props.intl.locale === "es";
     return (
-      <section className="Page LandingPage bg-secondary">
-        <div className="LandingPage__Hero">
+      <section className="Page LandingPage ">
+        <div className="LandingPage__Hero bg-secondary">
           <div className="LandingPage__HeroContent  container grid-md">
+            <div className="LandingPage__LangSwitches">
+              <Link
+                to={isSpanish ? "/en-US" : "/es"}
+                className="btn btn-block btn-default"
+              >
+                <Trans id={isSpanish ? "switch_en-US" : "switch_es"} />
+              </Link>
+            </div>
             <h2 className="LandingPage__HeroTitle">
               {this.content.hotlineTitle}
             </h2>
-            <div
-              dangerouslySetInnerHTML={{
-                __html: this.content.hotlineCta.childMarkdownRemark.html,
-              }}
-            />
+            <HcaPhone />
             <div
               dangerouslySetInnerHTML={{
                 __html: this.content.hotlineDescription.childMarkdownRemark
@@ -82,6 +86,10 @@ class LandingPage extends React.Component {
               }}
             />
             <br />
+          </div>
+        </div>
+        <div className="LandingPage__Hero">
+          <div className="LandingPage__HeroContent  container grid-md">
             <h2 className="LandingPage__HeroTitle">{this.content.heroTitle}</h2>
             <div
               className="LandingPage__HeroSubtitle"
@@ -98,25 +106,10 @@ class LandingPage extends React.Component {
               {this.content.heroButtonText}
               <i className="icon icon-forward ml-2"></i>
             </a>
-            <br />
-            <div className="LandingPage__LangSwitches">
-              <Link
-                to={isSpanish ? "/en-US" : "/es"}
-                className="btn btn-block btn-default"
-              >
-                <Trans id={isSpanish ? "switch_en-US" : "switch_es"} />
-              </Link>
-            </div>
-            <br />
-            <div>
-              <h6>
-                <Trans id="additionalResources" />
-              </h6>
-              <div className="accordion__item">
-                <CommunityGroups />
-              </div>
-            </div>
           </div>
+        </div>
+        <div className="accordion__item">
+          <CommunityGroups />
         </div>
       </section>
     );

--- a/src/containers/LandingPage.js
+++ b/src/containers/LandingPage.js
@@ -101,51 +101,18 @@ export const landingPageFragment = graphql`
         id
         node_locale
         pageTitle
-        moratoriumBanner {
-          childMarkdownRemark {
-            html
-          }
-        }
         heroTitle
-        heroSubTitle
         heroContent {
           childMarkdownRemark {
             html
           }
         }
         heroButtonText
-        heroImage {
-          title
-          sizes(maxWidth: 613) {
-            aspectRatio
-            sizes
-            src
-            srcSet
-          }
-        }
         hotlineTitle
         hotlineCta
         hotlineDescription {
           childMarkdownRemark {
             html
-          }
-        }
-        learnMoreTitle
-        faq {
-          title
-          content {
-            childMarkdownRemark {
-              html
-            }
-          }
-        }
-        secondaryImage {
-          title
-          sizes(maxWidth: 613) {
-            aspectRatio
-            sizes
-            src
-            srcSet
           }
         }
       }

--- a/src/containers/LandingPage.js
+++ b/src/containers/LandingPage.js
@@ -14,8 +14,6 @@ const propTypes = {
   data: PropTypes.object.isRequired,
 };
 
-const RTC_READ_MORE_LINK =
-  "https://www.righttocounselnyc.org/ny_eviction_moratorium_faq";
 const HCA_HOTLINE_LINK = "tel:12129624795";
 
 class LandingPage extends React.Component {
@@ -72,7 +70,7 @@ class LandingPage extends React.Component {
               }}
             />
             <a
-              href={RTC_READ_MORE_LINK}
+              href={this.content.heroButtonLink}
               target="_blank"
               className="btn btn-primary btn-large"
               rel="noopener noreferrer"
@@ -110,6 +108,7 @@ export const landingPageFragment = graphql`
           }
         }
         heroButtonText
+        heroButtonLink
         hotlineTitle
         hotlineCta
         hotlineDescription {

--- a/src/containers/LandingPage.js
+++ b/src/containers/LandingPage.js
@@ -33,7 +33,7 @@ class LandingPage extends React.Component {
             <div className="LandingPage__LangSwitches">
               <Link
                 to={isSpanish ? "/en-US" : "/es"}
-                className="btn btn-block btn-default"
+                className="btn btn-link btn-default"
               >
                 <Trans id={isSpanish ? "switch_en-US" : "switch_es"} />
               </Link>

--- a/src/containers/LandingPage.js
+++ b/src/containers/LandingPage.js
@@ -67,6 +67,18 @@ class LandingPage extends React.Component {
       <section className="Page LandingPage bg-secondary">
         <div className="LandingPage__Hero">
           <div className="LandingPage__HeroContent  container grid-md">
+          <h2 className="LandingPage__HeroTitle">{this.content.hotlineTitle}</h2>
+            <div
+              dangerouslySetInnerHTML={{
+                __html: this.content.hotlineCta.childMarkdownRemark.html,
+              }}
+            />
+            <div
+              dangerouslySetInnerHTML={{
+                __html: this.content.hotlineDescription.childMarkdownRemark.html,
+              }}
+            />
+            <br /> 
             <h2 className="LandingPage__HeroTitle">{this.content.heroTitle}</h2>
             <div
               className="LandingPage__HeroSubtitle"
@@ -80,24 +92,10 @@ class LandingPage extends React.Component {
               className="btn btn-block btn-primary btn-large"
               rel="noopener noreferrer"
             >
-              {isSpanish ? "Lea Noticias Recientes" : "Read Latest Updates"}
+              {this.content.heroButtonText}
               <i className="icon icon-forward ml-2"></i>
             </a>
-            {isSpanish ? <p>(Solo en inglés)</p> : <br />}
-            {isSpanish ? (
-              <p>
-                Llame a la línea de asistencia Housing Court Answers en el{" "}
-                <HcaPhone /> con preguntas legales o mande un email a{" "}
-                <RtcEmail /> para recibir más información y recursos para luchar
-                contra el desalojo.
-              </p>
-            ) : (
-              <p>
-                Call the Housing Court Answers hotline at <HcaPhone /> for legal
-                questions or email <RtcEmail /> for more information or
-                resources on how to fight evictions.
-              </p>
-            )}
+            <br />
             <div className="LandingPage__LangSwitches">
               <Link
                 to={isSpanish ? "/en-US" : "/es"}

--- a/src/containers/LandingPage.js
+++ b/src/containers/LandingPage.js
@@ -14,27 +14,6 @@ const propTypes = {
   data: PropTypes.object.isRequired,
 };
 
-const HcaPhone = () => (
-  <a
-    href="tel:12129624795"
-    target="_blank"
-    className="btn btn-block btn-primary btn-large"
-    rel="noopener noreferrer"
-  >
-    Call the Housing Court Answers hotline at 212-962-4795
-  </a>
-);
-const RtcEmail = () => (
-  <a
-    href="mailto:p.estupinan@newsettlement.org"
-    target="_blank"
-    rel="noopener noreferrer"
-    className="text-bold"
-  >
-    p.estupinan@newsettlement.org
-  </a>
-);
-
 class LandingPage extends React.Component {
   constructor(props) {
     super(props);
@@ -78,7 +57,14 @@ class LandingPage extends React.Component {
             <h2 className="LandingPage__HeroTitle">
               {this.content.hotlineTitle}
             </h2>
-            <HcaPhone />
+            <a
+              href="tel:12129624795"
+              target="_blank"
+              className="btn btn-block btn-primary btn-large"
+              rel="noopener noreferrer"
+            >
+              {this.content.hotlineCta}
+            </a>
             <div
               dangerouslySetInnerHTML={{
                 __html: this.content.hotlineDescription.childMarkdownRemark
@@ -150,11 +136,7 @@ export const landingPageFragment = graphql`
           }
         }
         hotlineTitle
-        hotlineCta {
-          childMarkdownRemark {
-            html
-          }
-        }
+        hotlineCta
         hotlineDescription {
           childMarkdownRemark {
             html

--- a/src/containers/LandingPage.js
+++ b/src/containers/LandingPage.js
@@ -67,7 +67,9 @@ class LandingPage extends React.Component {
       <section className="Page LandingPage bg-secondary">
         <div className="LandingPage__Hero">
           <div className="LandingPage__HeroContent  container grid-md">
-          <h2 className="LandingPage__HeroTitle">{this.content.hotlineTitle}</h2>
+            <h2 className="LandingPage__HeroTitle">
+              {this.content.hotlineTitle}
+            </h2>
             <div
               dangerouslySetInnerHTML={{
                 __html: this.content.hotlineCta.childMarkdownRemark.html,
@@ -75,10 +77,11 @@ class LandingPage extends React.Component {
             />
             <div
               dangerouslySetInnerHTML={{
-                __html: this.content.hotlineDescription.childMarkdownRemark.html,
+                __html: this.content.hotlineDescription.childMarkdownRemark
+                  .html,
               }}
             />
-            <br /> 
+            <br />
             <h2 className="LandingPage__HeroTitle">{this.content.heroTitle}</h2>
             <div
               className="LandingPage__HeroSubtitle"

--- a/src/containers/LandingPage.js
+++ b/src/containers/LandingPage.js
@@ -14,6 +14,10 @@ const propTypes = {
   data: PropTypes.object.isRequired,
 };
 
+const RTC_READ_MORE_LINK =
+  "https://www.righttocounselnyc.org/ny_eviction_moratorium_faq";
+const HCA_HOTLINE_LINK = "tel:12129624795";
+
 class LandingPage extends React.Component {
   constructor(props) {
     super(props);
@@ -42,7 +46,7 @@ class LandingPage extends React.Component {
               {this.content.hotlineTitle}
             </h2>
             <a
-              href="tel:12129624795"
+              href={HCA_HOTLINE_LINK}
               target="_blank"
               className="btn btn-block btn-primary btn-large"
               rel="noopener noreferrer"
@@ -68,7 +72,7 @@ class LandingPage extends React.Component {
               }}
             />
             <a
-              href="https://www.righttocounselnyc.org/organizing_covid19"
+              href={RTC_READ_MORE_LINK}
               target="_blank"
               className="btn btn-primary btn-large"
               rel="noopener noreferrer"

--- a/src/containers/LandingPage.js
+++ b/src/containers/LandingPage.js
@@ -22,23 +22,7 @@ class LandingPage extends React.Component {
     this.otherLangs = this.allLangs.filter((l) => l !== props.intl.locale);
 
     this.content = props.data.content.edges[0].node;
-    this.faq = this.content.faq.map((item) => ({
-      title: item.title,
-      html: this.addGetStartedButton(item.content.childMarkdownRemark.html),
-    }));
   }
-
-  addGetStartedButton = (html) => {
-    const locale = this.props.intl.locale;
-    const buttonText = this.content.heroButtonText;
-    return (html += `
-      <a class="btn btn-block btn-primary" href="/${locale}/questions">
-        ${buttonText}
-        <i class="icon icon-forward ml-2"></i>
-      </a>
-      <br />
-    `);
-  };
 
   render() {
     const isSpanish = this.props.intl.locale === "es";

--- a/src/containers/LandingPage.js
+++ b/src/containers/LandingPage.js
@@ -8,6 +8,7 @@ import ButtonLink from "../components/ButtonLink";
 import Accordion from "../components/Accordion";
 import widont from "widont";
 import "../styles/LandingPage.scss";
+import CommunityGroups from "../components/CommunityGroups";
 
 const propTypes = {
   data: PropTypes.object.isRequired,
@@ -66,16 +67,13 @@ class LandingPage extends React.Component {
       <section className="Page LandingPage bg-secondary">
         <div className="LandingPage__Hero">
           <div className="LandingPage__HeroContent  container grid-md">
-            <h2 className="LandingPage__HeroTitle">
-              {isSpanish
-                ? "La moratoria que protegía a los inquilinos de Nueva York ha terminado."
-                : "The moratorium protecting New Yorkers from eviction has expired."}
-            </h2>
-            <h4 className="LandingPage__HeroSubtitle">
-              {isSpanish
-                ? "Todos los casos de desalojo comenzarán el 12 de Octubre."
-                : "All eviction cases can move forward starting October 12."}
-            </h4>
+            <h2 className="LandingPage__HeroTitle">{this.content.heroTitle}</h2>
+            <div
+              className="LandingPage__HeroSubtitle"
+              dangerouslySetInnerHTML={{
+                __html: this.content.heroContent.childMarkdownRemark.html,
+              }}
+            />
             <a
               href="https://www.righttocounselnyc.org/organizing_covid19"
               target="_blank"
@@ -109,6 +107,14 @@ class LandingPage extends React.Component {
               </Link>
             </div>
             <br />
+            <div>
+              <h6>
+                <Trans id="additionalResources" />
+              </h6>
+              <div className="accordion__item">
+                <CommunityGroups />
+              </div>
+            </div>
           </div>
         </div>
       </section>
@@ -134,6 +140,11 @@ export const landingPageFragment = graphql`
         }
         heroTitle
         heroSubTitle
+        heroContent {
+          childMarkdownRemark {
+            html
+          }
+        }
         heroButtonText
         heroImage {
           title
@@ -142,6 +153,17 @@ export const landingPageFragment = graphql`
             sizes
             src
             srcSet
+          }
+        }
+        hotlineTitle
+        hotlineCta {
+          childMarkdownRemark {
+            html
+          }
+        }
+        hotlineDescription {
+          childMarkdownRemark {
+            html
           }
         }
         learnMoreTitle

--- a/src/containers/LandingPage.js
+++ b/src/containers/LandingPage.js
@@ -82,9 +82,11 @@ class LandingPage extends React.Component {
             </a>
           </div>
         </div>
-        <div className="accordion__item">
-          <CommunityGroups />
-        </div>
+        {process.env.GATSBY_ENABLE_COMMUNITY_GROUPS_LOOKUP && (
+          <div className="accordion__item">
+            <CommunityGroups />
+          </div>
+        )}
       </section>
     );
   }

--- a/src/data/languages.js
+++ b/src/data/languages.js
@@ -1,4 +1,4 @@
 module.exports = {
-  langs: ["en-US", "es", "fr", "ht"],
+  langs: ["en-US", "es"],
   defaultLangKey: "en-US",
 };

--- a/src/styles/CommunityGroups.scss
+++ b/src/styles/CommunityGroups.scss
@@ -4,6 +4,7 @@
   .tile {
     padding-top: 24px;
     padding-bottom: 24px;
+    margin: 2rem;
 
     &:not(:last-child) {
       border-bottom: 1px solid $border-color;

--- a/src/styles/CommunityGroups.scss
+++ b/src/styles/CommunityGroups.scss
@@ -45,8 +45,11 @@
         margin-bottom: 0;
       }
 
-      .btn + .btn {
-        margin-left: 8px;
+      .btn {
+        margin: 0.5rem 0;
+        &:first-child {
+          margin-right: 8px;
+        }
       }
 
       .btn--website {

--- a/src/styles/LandingPage.scss
+++ b/src/styles/LandingPage.scss
@@ -51,7 +51,7 @@
       }
 
       .LandingPage__HeroSubtitle {
-        margin-bottom: 1.5rem;
+        margin: 2rem 0;
 
         @include for-phone-only() {
           margin-bottom: 0.8rem;
@@ -63,17 +63,18 @@
           list-style-type: none;
           list-style-position: outside;
           li {
-            border: 1px solid #50596c33;
+            border: 1px solid #50596c66;
             padding: 1rem;
             margin: 1rem 0;
             counter-increment: step-counter;
             line-height: 1.5rem;
             &::before {
               content: counter(step-counter);
-              color: $secondary-color;
+              color: white;
+              background-color: $secondary-color;
               font-weight: bold;
               padding: 3px 7px;
-              border: 1px solid;
+              border: 1px solid $secondary-color;
               border-radius: 100%;
               margin-right: 0.5rem;
             }

--- a/src/styles/LandingPage.scss
+++ b/src/styles/LandingPage.scss
@@ -94,6 +94,10 @@
         margin: 16px auto;
         font-size: 0.8rem;
 
+        &.btn-link {
+          text-decoration: none;
+        }
+
         &.btn-primary {
           height: 3rem;
           padding: 1rem;

--- a/src/styles/LandingPage.scss
+++ b/src/styles/LandingPage.scss
@@ -27,12 +27,6 @@
         font-weight: 200;
         letter-spacing: 1px;
 
-        a {
-          color: inherit;
-          text-decoration: underline;
-          font-weight: bold;
-        }
-
         @include for-tablet-landscape-up() {
           max-width: 90%;
         }
@@ -64,7 +58,28 @@
 
         ol {
           margin-left: 0;
+          list-style-type: none;
+          list-style-position: outside;
           li {
+            border: 1px solid #50596c33;
+            padding: 1rem;
+            margin: 1rem 0;
+            counter-increment: step-counter;
+            line-height: 1.5rem;
+            &::before {
+              content: counter(step-counter);
+              color: $secondary-color;
+              font-weight: bold;
+              padding: 3px 7px;
+              border: 1px solid;
+              border-radius: 100%;
+              margin-right: 0.5rem;
+            }
+            a {
+              color: $secondary-color;
+              text-decoration: underline;
+              font-weight: 400;
+            }
             p:first-child {
               display: inline;
             }

--- a/src/styles/LandingPage.scss
+++ b/src/styles/LandingPage.scss
@@ -26,7 +26,7 @@
         letter-spacing: 1px;
 
         @include for-tablet-landscape-up() {
-          max-width: 75%;
+          max-width: 90%;
         }
       }
 
@@ -52,6 +52,18 @@
         @include for-phone-only() {
           margin-bottom: 0.8rem;
           font-size: 0.8rem;
+        }
+
+        ol {
+          margin-left: 0;
+          li {
+            p:first-child {
+              display: inline;
+            }
+            p:not(:first-child) {
+              margin: 0.5rem 0 1rem 1rem;
+            }
+          }
         }
       }
 

--- a/src/styles/LandingPage.scss
+++ b/src/styles/LandingPage.scss
@@ -6,8 +6,10 @@
 
   .LandingPage__Hero {
     padding: 0.75rem 0;
-    background: $secondary-color;
-    color: #fff;
+    &.bg-secondary {
+      background: $secondary-color;
+      color: #fff;
+    }
 
     // margin-bottom: 3rem;
     display: flex;
@@ -24,6 +26,12 @@
       p {
         font-weight: 200;
         letter-spacing: 1px;
+
+        a {
+          color: inherit;
+          text-decoration: underline;
+          font-weight: bold;
+        }
 
         @include for-tablet-landscape-up() {
           max-width: 90%;
@@ -74,8 +82,9 @@
         &.btn-primary {
           height: 3rem;
           padding: 1rem;
+          margin: 1.5rem 0;
           font-size: 1rem;
-          max-width: 260px;
+          max-width: fit-content;
         }
 
         &.btn-default {

--- a/src/styles/LandingPage.scss
+++ b/src/styles/LandingPage.scss
@@ -3,6 +3,8 @@
 .LandingPage {
   margin-top: 0;
   margin-bottom: 0;
+  // Fix issue with content extending beyond page horizontally
+  overflow-x: hidden;
 
   .LandingPage__Hero {
     padding: 0.75rem 0;
@@ -99,7 +101,8 @@
         }
 
         &.btn-primary {
-          height: 3rem;
+          height: fit-content;
+          white-space: normal;
           padding: 1rem;
           margin: 1.5rem 0;
           font-size: 1rem;


### PR DESCRIPTION
This PR restructures the landing page to EFNYC to include three sections as suggested by the Right to Counsel Coalition:

1. A banner/CTA pointing users to the Housing Court Answers hotline
2. A brief "Know Your Rights" section outlining the current state of eviction cases in NYC
3. A widget to search for community orgs around a given zip code

NOTE: the third feature (the widget) is currently disabled via the `GATSBY_ENABLE_COMMUNITY_GROUPS_LOOKUP` feature flag. Waiting on updated content before deploying this. 