### PR TITLE
Added capability to define new contentful host

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -27,6 +27,7 @@ module.exports = {
       options: {
         spaceId: process.env.CONTENTFUL_SPACE_ID,
         accessToken: process.env.CONTENTFUL_TOKEN,
+        host: process.env.CONTENTFUL_HOST || "cdn.contentful.com",
       },
     },
     {


### PR DESCRIPTION
This PR allows us to define our own "host" for our Contentful integration, which enables the use of the "Preview" API provided by contentful: https://www.contentful.com/developers/docs/references/content-preview-api/