### PR TITLE
Add content for interim EFNYC landing page

### DIFF
--- a/src/components/GetInvolved.js
+++ b/src/components/GetInvolved.js
@@ -63,7 +63,7 @@ const GetInvolved = () => (
             <script type="text/javascript" defer src="//www.123formbuilder.com/embed/3538714.js" data-role="form" data-default-width="650px"></script> */}
 
             <a
-              href="https://www.righttocounselnyc.org/join#middle"
+              href="https://www.righttocounselnyc.org/sign_up"
               target="_blank"
               className="btn btn-primary btn-block"
             >
@@ -82,7 +82,7 @@ const GetInvolved = () => (
               <Trans id="eventsTitle" />
             </label>
             <a
-              href="https://www.righttocounselnyc.org/upcoming_events#middle"
+              href="https://www.righttocounselnyc.org/blog"
               target="_blank"
               className="btn btn-primary btn-block"
             >

--- a/src/containers/LandingPage.js
+++ b/src/containers/LandingPage.js
@@ -43,14 +43,6 @@ class LandingPage extends React.Component {
             <h2 className="LandingPage__HeroTitle">
               {this.content.hotlineTitle}
             </h2>
-            <a
-              href={HCA_HOTLINE_LINK}
-              target="_blank"
-              className="btn btn-block btn-primary btn-large"
-              rel="noopener noreferrer"
-            >
-              {this.content.hotlineCta}
-            </a>
             <div
               dangerouslySetInnerHTML={{
                 __html: this.content.hotlineDescription.childMarkdownRemark
@@ -78,13 +70,28 @@ class LandingPage extends React.Component {
               {this.content.heroButtonText}
               <i className="icon icon-forward ml-2"></i>
             </a>
+            <br />
+            <br />
+            <h2 className="LandingPage__HeroTitle">
+              {this.content.heroTitle2}
+            </h2>
+            <div
+              className="LandingPage__HeroSubtitle"
+              dangerouslySetInnerHTML={{
+                __html: this.content.heroContent2.childMarkdownRemark.html,
+              }}
+            />
+            <a
+              href={this.content.heroButtonLink2}
+              target="_blank"
+              className="btn btn-primary btn-large"
+              rel="noopener noreferrer"
+            >
+              {this.content.heroButtonText2}
+              <i className="icon icon-forward ml-2"></i>
+            </a>
           </div>
         </div>
-        {process.env.GATSBY_ENABLE_COMMUNITY_GROUPS_LOOKUP && (
-          <div className="accordion__item">
-            <CommunityGroups />
-          </div>
-        )}
       </section>
     );
   }
@@ -109,6 +116,14 @@ export const landingPageFragment = graphql`
         }
         heroButtonText
         heroButtonLink
+        heroTitle2
+        heroContent2 {
+          childMarkdownRemark {
+            html
+          }
+        }
+        heroButtonText2
+        heroButtonLink2
         hotlineTitle
         hotlineCta
         hotlineDescription {

--- a/src/styles/LandingPage.scss
+++ b/src/styles/LandingPage.scss
@@ -156,11 +156,9 @@
       }
     }
 
-    @include for-tablet-landscape-up() {
-      justify-content: flex-start;
-      text-align: left;
-      padding: 2.5rem 0 1rem 0;
-    }
+    justify-content: flex-start;
+    text-align: left;
+    padding: 2.5rem 0 1rem 0;
 
     .LandingPage__HeroLearnMore {
       text-align: center;

--- a/src/styles/LandingPage.scss
+++ b/src/styles/LandingPage.scss
@@ -51,7 +51,7 @@
       }
 
       .LandingPage__HeroSubtitle {
-        margin: 2rem 0;
+        margin: 2rem 0 0 0;
 
         @include for-phone-only() {
           margin-bottom: 0.8rem;


### PR DESCRIPTION
This page adds new content to our landing page that acts as a placeholder before we launch our new EFNYC 2.0 tool with RTC/HJ4A