### PR TITLE
Add Read Latest Updates button to landing page

### DIFF
--- a/src/containers/LandingPage.js
+++ b/src/containers/LandingPage.js
@@ -49,6 +49,15 @@ class LandingPage extends React.Component {
                   .html,
               }}
             />
+            <a
+              href={this.content.learnMoreLink}
+              target="_blank"
+              className="btn btn-block btn-primary btn-large"
+              rel="noopener noreferrer"
+            >
+              {this.content.learnMoreTitle}
+              <i className="icon icon-forward ml-2"></i>
+            </a>
             <br />
           </div>
         </div>
@@ -131,6 +140,8 @@ export const landingPageFragment = graphql`
             html
           }
         }
+        learnMoreTitle
+        learnMoreLink
       }
     }
   }


### PR DESCRIPTION
This PR builds on #136 by adding the missing "Read Latest Updates" button that was slated to appear in the first section of the new landing page.