### PR TITLE
Revert interim EFNYC landing page for archival demo site

### DIFF
--- a/.env.development.sample
+++ b/.env.development.sample
@@ -37,10 +37,3 @@ TWILIO_PHONE_NUMBER=
 ## If left undefined, this var will default to "www.evictionfreenyc.org." 
 
 GATSBY_EFNYC_HOST=
-
-## GATSBY_ENABLE_COMMUNITY_GROUPS_LOOKUP (Optional)
-## 
-## This feature flag, if defined, will trigger our CommunityGroups component to render
-## on our landing page. Otherwise, it will not be shown. 
-
-GATSBY_ENABLE_COMMUNITY_GROUPS_LOOKUP=

--- a/src/components/CommunityGroups.js
+++ b/src/components/CommunityGroups.js
@@ -50,71 +50,62 @@ class CommunityGroups extends React.Component {
       <div className="CommunityGroups">
         {this.state.groups.length ? (
           <div>
-            <div className="empty">
-              <p className="empty-title h3">
-                <Trans id="groupsSearch" />
-              </p>
-            </div>
-            <div>
-              {this.state.groups.map((group, idx) => (
-                <div className="tile" key={idx}>
-                  <div className="tile-icon">
-                    {group.logo && <img src={group.logo.fields.file.url} />}
-                  </div>
-                  <div className="tile-content">
-                    <p className="tile-title">{group.title}</p>
-                    {group.address && (
-                      <p className="tile-subtitle text-gray">
-                        <i className="icon icon-location mr-2"></i>
-                        <a
-                          href={`https://maps.google.com/maps/place/${group.address}`}
-                          target="_blank"
-                        >
-                          {group.address}
-                        </a>
-                      </p>
-                    )}
-                    {group.intakeInstructions && (
-                      <p className="title-subtitle text-gray">
-                        <i className="icon icon-time mr-2"></i>
-                        {group.intakeInstructions}
-                      </p>
-                    )}
-                    <p className="tile-subtitle text-gray">
-                      {group.description}
-                    </p>
-                    <p>
-                      <a
-                        href={`tel:${group.phoneNumber}`}
-                        className="btn btn-success"
-                      >
-                        {createFormattedTel(group.phoneNumber)}
-                      </a>
-                      {group.website && (
-                        <a
-                          href={group.website}
-                          target="_blank"
-                          className="btn btn-default btn--website"
-                        >
-                          <i className="icon icon-share mr-2"></i>
-                          <Trans id="website" />
-                        </a>
-                      )}
-                    </p>
-                  </div>
+            {this.state.groups.map((group, idx) => (
+              <div className="tile" key={idx}>
+                <div className="tile-icon">
+                  {group.logo && <img src={group.logo.fields.file.url} />}
                 </div>
-              ))}
-            </div>
+                <div className="tile-content">
+                  <p className="tile-title">{group.title}</p>
+                  {group.address && (
+                    <p className="tile-subtitle text-gray">
+                      <i className="icon icon-location mr-2"></i>
+                      <a
+                        href={`https://maps.google.com/maps/place/${group.address}`}
+                        target="_blank"
+                      >
+                        {group.address}
+                      </a>
+                    </p>
+                  )}
+                  {group.intakeInstructions && (
+                    <p className="title-subtitle text-gray">
+                      <i className="icon icon-time mr-2"></i>
+                      {group.intakeInstructions}
+                    </p>
+                  )}
+                  <p className="tile-subtitle text-gray">{group.description}</p>
+                  <p>
+                    <a
+                      href={`tel:${group.phoneNumber}`}
+                      className="btn btn-success"
+                    >
+                      {createFormattedTel(group.phoneNumber)}
+                    </a>
+                    {group.website && (
+                      <a
+                        href={group.website}
+                        target="_blank"
+                        className="btn btn-default btn--website"
+                      >
+                        <i className="icon icon-share mr-2"></i>
+                        <Trans id="website" />
+                      </a>
+                    )}
+                  </p>
+                </div>
+              </div>
+            ))}
           </div>
         ) : this.state.contentfulResponse ? (
           <div className="empty">
-            <p className="empty-title h3">
+            <p className="empty-title h5">
               <Trans id="groupsEmpty" />
             </p>
           </div>
         ) : (
           <div className="empty">
-            <p className="empty-title h3">
+            <p className="empty-title h5">
               <Trans id="groupsSearch" />
             </p>
             <div className="empty-action">

--- a/src/components/GetInvolved.js
+++ b/src/components/GetInvolved.js
@@ -63,7 +63,7 @@ const GetInvolved = () => (
             <script type="text/javascript" defer src="//www.123formbuilder.com/embed/3538714.js" data-role="form" data-default-width="650px"></script> */}
 
             <a
-              href="https://www.righttocounselnyc.org/sign_up"
+              href="https://www.righttocounselnyc.org/join#middle"
               target="_blank"
               className="btn btn-primary btn-block"
             >
@@ -82,7 +82,7 @@ const GetInvolved = () => (
               <Trans id="eventsTitle" />
             </label>
             <a
-              href="https://www.righttocounselnyc.org/blog"
+              href="https://www.righttocounselnyc.org/upcoming_events#middle"
               target="_blank"
               className="btn btn-primary btn-block"
             >

--- a/src/containers/LandingPage.js
+++ b/src/containers/LandingPage.js
@@ -43,6 +43,14 @@ class LandingPage extends React.Component {
             <h2 className="LandingPage__HeroTitle">
               {this.content.hotlineTitle}
             </h2>
+            <a
+              href={HCA_HOTLINE_LINK}
+              target="_blank"
+              className="btn btn-block btn-primary btn-large"
+              rel="noopener noreferrer"
+            >
+              {this.content.hotlineCta}
+            </a>
             <div
               dangerouslySetInnerHTML={{
                 __html: this.content.hotlineDescription.childMarkdownRemark
@@ -70,28 +78,13 @@ class LandingPage extends React.Component {
               {this.content.heroButtonText}
               <i className="icon icon-forward ml-2"></i>
             </a>
-            <br />
-            <br />
-            <h2 className="LandingPage__HeroTitle">
-              {this.content.heroTitle2}
-            </h2>
-            <div
-              className="LandingPage__HeroSubtitle"
-              dangerouslySetInnerHTML={{
-                __html: this.content.heroContent2.childMarkdownRemark.html,
-              }}
-            />
-            <a
-              href={this.content.heroButtonLink2}
-              target="_blank"
-              className="btn btn-primary btn-large"
-              rel="noopener noreferrer"
-            >
-              {this.content.heroButtonText2}
-              <i className="icon icon-forward ml-2"></i>
-            </a>
           </div>
         </div>
+        {process.env.GATSBY_ENABLE_COMMUNITY_GROUPS_LOOKUP && (
+          <div className="accordion__item">
+            <CommunityGroups />
+          </div>
+        )}
       </section>
     );
   }
@@ -116,14 +109,6 @@ export const landingPageFragment = graphql`
         }
         heroButtonText
         heroButtonLink
-        heroTitle2
-        heroContent2 {
-          childMarkdownRemark {
-            html
-          }
-        }
-        heroButtonText2
-        heroButtonLink2
         hotlineTitle
         hotlineCta
         hotlineDescription {

--- a/src/containers/LandingPage.js
+++ b/src/containers/LandingPage.js
@@ -49,15 +49,6 @@ class LandingPage extends React.Component {
                   .html,
               }}
             />
-            <a
-              href={this.content.learnMoreLink}
-              target="_blank"
-              className="btn btn-block btn-primary btn-large"
-              rel="noopener noreferrer"
-            >
-              {this.content.learnMoreTitle}
-              <i className="icon icon-forward ml-2"></i>
-            </a>
             <br />
           </div>
         </div>
@@ -140,8 +131,6 @@ export const landingPageFragment = graphql`
             html
           }
         }
-        learnMoreTitle
-        learnMoreLink
       }
     }
   }

--- a/src/containers/LandingPage.js
+++ b/src/containers/LandingPage.js
@@ -45,15 +45,6 @@ class LandingPage extends React.Component {
       <section className="Page LandingPage">
         <div className="LandingPage__Hero">
           <div className="LandingPage__HeroContent  container grid-md">
-            <div
-              className="LandingPage__WarningBanner toast toast-warning text-left"
-              dangerouslySetInnerHTML={{
-                __html: widont(
-                  c.moratoriumBanner.childMarkdownRemark.html,
-                  "html"
-                ),
-              }}
-            />
             <h2 className="LandingPage__HeroTitle">{c.heroTitle}</h2>
             <h4 className="LandingPage__HeroSubtitle">{c.heroSubTitle}</h4>
             <ButtonLink to={`/questions`} type="primary">
@@ -111,11 +102,6 @@ export const landingPageFragment = graphql`
         id
         node_locale
         pageTitle
-        moratoriumBanner {
-          childMarkdownRemark {
-            html
-          }
-        }
         heroTitle
         heroSubTitle
         heroButtonText

--- a/src/containers/LandingPage.js
+++ b/src/containers/LandingPage.js
@@ -8,13 +8,31 @@ import ButtonLink from "../components/ButtonLink";
 import Accordion from "../components/Accordion";
 import widont from "widont";
 import "../styles/LandingPage.scss";
-import CommunityGroups from "../components/CommunityGroups";
 
 const propTypes = {
   data: PropTypes.object.isRequired,
 };
 
-const HCA_HOTLINE_LINK = "tel:12129624795";
+const HcaPhone = () => (
+  <a
+    href="tel:12129624795"
+    target="_blank"
+    className="text-bold"
+    rel="noopener noreferrer"
+  >
+    212-962-4795
+  </a>
+);
+const RtcEmail = () => (
+  <a
+    href="mailto:p.estupinan@newsettlement.org"
+    target="_blank"
+    rel="noopener noreferrer"
+    className="text-bold"
+  >
+    p.estupinan@newsettlement.org
+  </a>
+);
 
 class LandingPage extends React.Component {
   constructor(props) {
@@ -24,67 +42,75 @@ class LandingPage extends React.Component {
     this.otherLangs = this.allLangs.filter((l) => l !== props.intl.locale);
 
     this.content = props.data.content.edges[0].node;
+    this.faq = this.content.faq.map((item) => ({
+      title: item.title,
+      html: this.addGetStartedButton(item.content.childMarkdownRemark.html),
+    }));
   }
+
+  addGetStartedButton = (html) => {
+    const locale = this.props.intl.locale;
+    const buttonText = this.content.heroButtonText;
+    return (html += `
+      <a class="btn btn-block btn-primary" href="/${locale}/questions">
+        ${buttonText}
+        <i class="icon icon-forward ml-2"></i>
+      </a>
+      <br />
+    `);
+  };
 
   render() {
     const isSpanish = this.props.intl.locale === "es";
     return (
-      <section className="Page LandingPage ">
-        <div className="LandingPage__Hero bg-secondary">
+      <section className="Page LandingPage bg-secondary">
+        <div className="LandingPage__Hero">
           <div className="LandingPage__HeroContent  container grid-md">
-            <div className="LandingPage__LangSwitches">
-              <Link
-                to={isSpanish ? "/en-US" : "/es"}
-                className="btn btn-link btn-default"
-              >
-                <Trans id={isSpanish ? "switch_en-US" : "switch_es"} />
-              </Link>
-            </div>
             <h2 className="LandingPage__HeroTitle">
-              {this.content.hotlineTitle}
+              {isSpanish
+                ? "La moratoria que protegía a los inquilinos de Nueva York ha terminado."
+                : "The moratorium protecting New Yorkers from eviction has expired."}
             </h2>
+            <h4 className="LandingPage__HeroSubtitle">
+              {isSpanish
+                ? "Todos los casos de desalojo comenzarán el 12 de Octubre."
+                : "All eviction cases can move forward starting October 12."}
+            </h4>
             <a
-              href={HCA_HOTLINE_LINK}
+              href="https://www.righttocounselnyc.org/organizing_covid19"
               target="_blank"
               className="btn btn-block btn-primary btn-large"
               rel="noopener noreferrer"
             >
-              {this.content.hotlineCta}
+              {isSpanish ? "Lea Noticias Recientes" : "Read Latest Updates"}
+              <i className="icon icon-forward ml-2"></i>
             </a>
-            <div
-              dangerouslySetInnerHTML={{
-                __html: this.content.hotlineDescription.childMarkdownRemark
-                  .html,
-              }}
-            />
+            {isSpanish ? <p>(Solo en inglés)</p> : <br />}
+            {isSpanish ? (
+              <p>
+                Llame a la línea de asistencia Housing Court Answers en el{" "}
+                <HcaPhone /> con preguntas legales o mande un email a{" "}
+                <RtcEmail /> para recibir más información y recursos para luchar
+                contra el desalojo.
+              </p>
+            ) : (
+              <p>
+                Call the Housing Court Answers hotline at <HcaPhone /> for legal
+                questions or email <RtcEmail /> for more information or
+                resources on how to fight evictions.
+              </p>
+            )}
+            <div className="LandingPage__LangSwitches">
+              <Link
+                to={isSpanish ? "/en-US" : "/es"}
+                className="btn btn-block btn-default"
+              >
+                <Trans id={isSpanish ? "switch_en-US" : "switch_es"} />
+              </Link>
+            </div>
             <br />
           </div>
         </div>
-        <div className="LandingPage__Hero">
-          <div className="LandingPage__HeroContent  container grid-md">
-            <h2 className="LandingPage__HeroTitle">{this.content.heroTitle}</h2>
-            <div
-              className="LandingPage__HeroSubtitle"
-              dangerouslySetInnerHTML={{
-                __html: this.content.heroContent.childMarkdownRemark.html,
-              }}
-            />
-            <a
-              href={this.content.heroButtonLink}
-              target="_blank"
-              className="btn btn-primary btn-large"
-              rel="noopener noreferrer"
-            >
-              {this.content.heroButtonText}
-              <i className="icon icon-forward ml-2"></i>
-            </a>
-          </div>
-        </div>
-        {process.env.GATSBY_ENABLE_COMMUNITY_GROUPS_LOOKUP && (
-          <div className="accordion__item">
-            <CommunityGroups />
-          </div>
-        )}
       </section>
     );
   }
@@ -101,19 +127,39 @@ export const landingPageFragment = graphql`
         id
         node_locale
         pageTitle
-        heroTitle
-        heroContent {
+        moratoriumBanner {
           childMarkdownRemark {
             html
           }
         }
+        heroTitle
+        heroSubTitle
         heroButtonText
-        heroButtonLink
-        hotlineTitle
-        hotlineCta
-        hotlineDescription {
-          childMarkdownRemark {
-            html
+        heroImage {
+          title
+          sizes(maxWidth: 613) {
+            aspectRatio
+            sizes
+            src
+            srcSet
+          }
+        }
+        learnMoreTitle
+        faq {
+          title
+          content {
+            childMarkdownRemark {
+              html
+            }
+          }
+        }
+        secondaryImage {
+          title
+          sizes(maxWidth: 613) {
+            aspectRatio
+            sizes
+            src
+            srcSet
           }
         }
       }

--- a/src/containers/LandingPage.js
+++ b/src/containers/LandingPage.js
@@ -13,27 +13,6 @@ const propTypes = {
   data: PropTypes.object.isRequired,
 };
 
-const HcaPhone = () => (
-  <a
-    href="tel:12129624795"
-    target="_blank"
-    className="text-bold"
-    rel="noopener noreferrer"
-  >
-    212-962-4795
-  </a>
-);
-const RtcEmail = () => (
-  <a
-    href="mailto:p.estupinan@newsettlement.org"
-    target="_blank"
-    rel="noopener noreferrer"
-    className="text-bold"
-  >
-    p.estupinan@newsettlement.org
-  </a>
-);
-
 class LandingPage extends React.Component {
   constructor(props) {
     super(props);
@@ -61,54 +40,59 @@ class LandingPage extends React.Component {
   };
 
   render() {
-    const isSpanish = this.props.intl.locale === "es";
+    const c = this.content;
     return (
-      <section className="Page LandingPage bg-secondary">
+      <section className="Page LandingPage">
         <div className="LandingPage__Hero">
           <div className="LandingPage__HeroContent  container grid-md">
-            <h2 className="LandingPage__HeroTitle">
-              {isSpanish
-                ? "La moratoria que protegía a los inquilinos de Nueva York ha terminado."
-                : "The moratorium protecting New Yorkers from eviction has expired."}
-            </h2>
-            <h4 className="LandingPage__HeroSubtitle">
-              {isSpanish
-                ? "Todos los casos de desalojo comenzarán el 12 de Octubre."
-                : "All eviction cases can move forward starting October 12."}
-            </h4>
-            <a
-              href="https://www.righttocounselnyc.org/organizing_covid19"
-              target="_blank"
-              className="btn btn-block btn-primary btn-large"
-              rel="noopener noreferrer"
-            >
-              {isSpanish ? "Lea Noticias Recientes" : "Read Latest Updates"}
+            <div
+              className="LandingPage__WarningBanner toast toast-warning text-left"
+              dangerouslySetInnerHTML={{
+                __html: widont(
+                  c.moratoriumBanner.childMarkdownRemark.html,
+                  "html"
+                ),
+              }}
+            />
+            <h2 className="LandingPage__HeroTitle">{c.heroTitle}</h2>
+            <h4 className="LandingPage__HeroSubtitle">{c.heroSubTitle}</h4>
+            <ButtonLink to={`/questions`} type="primary">
+              {c.heroButtonText}
               <i className="icon icon-forward ml-2"></i>
-            </a>
-            {isSpanish ? <p>(Solo en inglés)</p> : <br />}
-            {isSpanish ? (
-              <p>
-                Llame a la línea de asistencia Housing Court Answers en el{" "}
-                <HcaPhone /> con preguntas legales o mande un email a{" "}
-                <RtcEmail /> para recibir más información y recursos para luchar
-                contra el desalojo.
-              </p>
-            ) : (
-              <p>
-                Call the Housing Court Answers hotline at <HcaPhone /> for legal
-                questions or email <RtcEmail /> for more information or
-                resources on how to fight evictions.
-              </p>
-            )}
+            </ButtonLink>
             <div className="LandingPage__LangSwitches">
-              <Link
-                to={isSpanish ? "/en-US" : "/es"}
-                className="btn btn-block btn-default"
-              >
-                <Trans id={isSpanish ? "switch_en-US" : "switch_es"} />
-              </Link>
+              {this.otherLangs.map((lang, idx) => (
+                <Link
+                  to={`/${lang}`}
+                  key={idx}
+                  className="btn btn-block btn-default"
+                >
+                  <Trans id={`switch_${lang}`} />
+                  <i className="icon icon-forward ml-2"></i>
+                </Link>
+              ))}
             </div>
-            <br />
+            <div className="LandingPage__HeroLearnMore">
+              <div>{c.learnMoreTitle}</div>
+              <i className="icon icon-arrow-down"></i>
+            </div>
+          </div>
+        </div>
+        <div id="faq" className="LandingPage__Content container grid-md">
+          <div className="columns clearfix">
+            <div className="LandingPage__ContentFAQ column col-mr-auto col-sm-12 col-7">
+              <h3>{c.learnMoreTitle}:</h3>
+              <Accordion content={this.faq} />
+            </div>
+            <div className="LandingPage__ContentImage1 column col-ml-auto col-sm-12 col-4">
+              <Img alt={c.heroImage.title} sizes={c.heroImage.sizes} />
+            </div>
+            <div className="LandingPage__ContentImage2 column col-sm-12 col-4">
+              <Img
+                alt={c.secondaryImage.title}
+                sizes={c.secondaryImage.sizes}
+              />
+            </div>
           </div>
         </div>
       </section>

--- a/src/data/languages.js
+++ b/src/data/languages.js
@@ -1,4 +1,4 @@
 module.exports = {
-  langs: ["en-US", "es"],
+  langs: ["en-US", "es", "fr", "ht"],
   defaultLangKey: "en-US",
 };

--- a/src/styles/CommunityGroups.scss
+++ b/src/styles/CommunityGroups.scss
@@ -4,7 +4,6 @@
   .tile {
     padding-top: 24px;
     padding-bottom: 24px;
-    margin: 2rem;
 
     &:not(:last-child) {
       border-bottom: 1px solid $border-color;
@@ -45,11 +44,8 @@
         margin-bottom: 0;
       }
 
-      .btn {
-        margin: 0.5rem 0;
-        &:first-child {
-          margin-right: 8px;
-        }
+      .btn + .btn {
+        margin-left: 8px;
       }
 
       .btn--website {

--- a/src/styles/LandingPage.scss
+++ b/src/styles/LandingPage.scss
@@ -51,7 +51,7 @@
       }
 
       .LandingPage__HeroSubtitle {
-        margin: 2rem 0 0 0;
+        margin: 2rem 0;
 
         @include for-phone-only() {
           margin-bottom: 0.8rem;
@@ -159,9 +159,11 @@
       }
     }
 
-    justify-content: flex-start;
-    text-align: left;
-    padding: 2.5rem 0 1rem 0;
+    @include for-tablet-landscape-up() {
+      justify-content: flex-start;
+      text-align: left;
+      padding: 2.5rem 0 1rem 0;
+    }
 
     .LandingPage__HeroLearnMore {
       text-align: center;

--- a/src/styles/LandingPage.scss
+++ b/src/styles/LandingPage.scss
@@ -2,7 +2,6 @@
 
 .LandingPage {
   margin-top: 0;
-  margin-bottom: 0;
 
   .LandingPage__Hero {
     padding: 0.75rem 0;
@@ -20,8 +19,7 @@
       margin-bottom: 0.5rem;
 
       h2,
-      h4,
-      p {
+      h4 {
         font-weight: 200;
         letter-spacing: 1px;
 
@@ -94,14 +92,6 @@
 
       .btn {
         margin: 16px auto;
-        font-size: 0.8rem;
-
-        &.btn-primary {
-          height: 3rem;
-          padding: 1rem;
-          font-size: 1rem;
-          max-width: 260px;
-        }
 
         &.btn-default {
           color: #fff;

--- a/src/styles/LandingPage.scss
+++ b/src/styles/LandingPage.scss
@@ -3,15 +3,11 @@
 .LandingPage {
   margin-top: 0;
   margin-bottom: 0;
-  // Fix issue with content extending beyond page horizontally
-  overflow-x: hidden;
 
   .LandingPage__Hero {
     padding: 0.75rem 0;
-    &.bg-secondary {
-      background: $secondary-color;
-      color: #fff;
-    }
+    background: $secondary-color;
+    color: #fff;
 
     // margin-bottom: 3rem;
     display: flex;
@@ -30,7 +26,7 @@
         letter-spacing: 1px;
 
         @include for-tablet-landscape-up() {
-          max-width: 90%;
+          max-width: 75%;
         }
       }
 
@@ -51,7 +47,7 @@
       }
 
       .LandingPage__HeroSubtitle {
-        margin: 2rem 0;
+        margin-bottom: 1.5rem;
 
         @include for-phone-only() {
           margin-bottom: 0.8rem;
@@ -100,17 +96,11 @@
         margin: 16px auto;
         font-size: 0.8rem;
 
-        &.btn-link {
-          text-decoration: none;
-        }
-
         &.btn-primary {
-          height: fit-content;
-          white-space: normal;
+          height: 3rem;
           padding: 1rem;
-          margin: 1.5rem 0;
           font-size: 1rem;
-          max-width: fit-content;
+          max-width: 260px;
         }
 
         &.btn-default {


### PR DESCRIPTION
This brings back the old EFNYC landing page for archival purposes.